### PR TITLE
Fix Gradle wrapper config

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,9 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="LOCAL" />
+        <!-- Use the Gradle wrapper bundled with the project -->
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="C:\Program Files\Android\Android Studio\gradle\gradle-2.14.1" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 34
+    namespace = 'com.fm.dev.exercises.palindromo'
     defaultConfig {
         applicationId "com.fm.dev.exercises.palindromo"
         minSdkVersion 15


### PR DESCRIPTION
## Summary
- fix Android Studio gradleHome path by using the wrapper
- add required namespace field in `app/build.gradle`

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_68506f22ad18832e83c8fb7f4a8efe31