### PR TITLE
Fix build with higher minSdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     namespace = 'com.fm.dev.exercises.palindromo'
     defaultConfig {
         applicationId "com.fm.dev.exercises.palindromo"
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 34
         versionCode 3
         versionName "1.0.2"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.fm.dev.exercises.palindromo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Include required permissions for Google Mobile Ads to run. -->
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
## Summary
- raise `minSdkVersion` to 21 to satisfy `appcompat-resources`
- remove old `package` attribute from `AndroidManifest`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d2ad6674832ea20ee3a1b4328bc7