### PR TITLE
Fix crash due to missing AdMob App ID

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,11 @@
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
 
+        <!-- AdMob App ID required for Mobile Ads SDK initialization -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
+
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"


### PR DESCRIPTION
## Summary
- add AdMob `APPLICATION_ID` to `AndroidManifest.xml` so Mobile Ads SDK initializes properly

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517094b440832e8f1267786641ded3