### PR TITLE
Fix missing instrumentation test dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation('androidx.test.espresso:espresso-core:3.5.1', {
         exclude group: 'androidx.annotation', module: 'annotation'
     })


### PR DESCRIPTION
## Summary
- include AndroidX test dependency to support `AndroidJUnit4`

## Testing
- `./gradlew :app:assembleDebug :app:assembleDebugUnitTest :app:assembleDebugAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b418c758832eb63ad442519b113c